### PR TITLE
Jquery 3.x: Fix [shorthand-deprecated-v3] and  [pre-on-methods]

### DIFF
--- a/jquery.treeview.js
+++ b/jquery.treeview.js
@@ -59,7 +59,7 @@
 		},
 		applyClasses: function(settings, toggler) {
 			// TODO use event delegation
-			this.filter(":has(>ul):not(:has(>a))").find(">span").unbind("click.treeview").bind("click.treeview", function(event) {
+			this.filter(":has(>ul):not(:has(>a))").find(">span").off("click.treeview").on("click.treeview", function(event) {
 				// don't handle click events on children, eg. checkboxes
 				if ( this == event.target )
 					toggler.apply($(this).next());
@@ -86,11 +86,11 @@
 						classes += this + "-hitarea ";
 					});
 					$(this).addClass( classes );
-				})
+			    });
 			}
 
 			// apply event to hitarea
-			this.find("div." + CLASSES.hitarea).click( toggler );
+			this.find("div." + CLASSES.hitarea).on("click", toggler );
 		},
 		treeview: function(settings) {
 


### PR DESCRIPTION
query 3.x: Fix [shorthand-deprecated-v3] JQMIGRATE: jQuery.fn.click() event shorthand is deprecated and [pre-on-methods] JQMIGRATE: jQuery.fn.unbind() is deprecated.
See https://github.com/jquery/jquery-migrate/blob/main/warnings.md
